### PR TITLE
Dereference symlinks to capture changes to config

### DIFF
--- a/w3
+++ b/w3
@@ -45,7 +45,7 @@ def cp_tree(src, dest):
     '''Replaces dest with a copy of src.'''
     rm_tree(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
-    check_call(['cp', '-r', str(src), str(dest)])
+    check_call(['cp', '-Lr', str(src), str(dest)])
 
 def files_differ(a, b):
     return bool(call(['diff', str(a), str(b)], stdout=DEVNULL))


### PR DESCRIPTION
When configuration files are sysmlinks, as they are when I use `rcm`,
these files need to be dereferenced so weechat doesn't apply these
changes to the original code.