### PR TITLE
Use python3 instead of python3.5

### DIFF
--- a/w3
+++ b/w3
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 #
 # w3: the wee weechat wrapper
 #


### PR DESCRIPTION
I am currently using python 3.6.0 with success, so the less script
bounds should be used.